### PR TITLE
Arrange Grunt task aliases in logical order

### DIFF
--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -1,24 +1,36 @@
+# primary tasks
 default:
-- 'clean'
-- 'jsbeautifier'
-- 'jshint'
-- 'copy'
-- 'stylus'
-- 'autoprefixer'
-- 'assemble'
+- 'dev'
+
+dev:
+- 'prep'
+- 'assemble:dev'
 - 'connect:dev'
 - 'watch'
 
-production:
+prod:
+- 'prep'
+- 'assemble:prod'
+- 'optimize'
+- 'connect:prod'
+- 'watch'
+
+ci:
+- 'prep'
+- 'assemble:prod'
+- 'optimize'
+- 'connect:prod'
+
+# task groups
+prep:
+- 'jsbeautifier'
+- 'jshint'
+- 'clean'
+- 'copy'
+- 'stylus'
+- 'autoprefixer'
+
+optimize:
 - 'cmq'
 - 'groundskeeper'
 - 'modernizr'
-
-ci:
-- 'clean'
-- 'jsbeautifier'
-- 'jshint'
-- 'copy'
-
-ci-test:
-- 'connect:prod'


### PR DESCRIPTION
- Primary tasks group commands for different environments (dev, prod, ci)
- Task groups supply the above

Closes #6
